### PR TITLE
feat: update backend and storefront dockerfiles

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,19 +1,22 @@
-FROM node:17.1.0
+#Dependencies
+FROM node:18-alpine3.16 as deps
+WORKDIR /app/medusa/
+#   Copy medusa package.json and yarn.lock from /backend
+COPY ./backend/package.json .
+COPY ./backend/yarn.lock .
+#   Install deps
+RUN yarn install --frozen-lockfile
 
+#Build
+FROM node:18-alpine3.16 as builder
 WORKDIR /app/medusa
-
-COPY package.json .
-
-RUN apt-get update
-
-RUN apt-get install -y python
-
-RUN npm install -g npm@latest
-
-RUN npm install -g @medusajs/medusa-cli@latest
-
-RUN npm install --loglevel=error
-
-COPY . .
-
-ENTRYPOINT ["./develop.sh", "develop"]
+#   Copy cached node_modules from deps
+COPY --from=deps /app/medusa/node_modules /app/medusa/node_modules
+#   Install python and medusa-cli
+RUN apk update
+RUN apk add python3
+RUN yarn global add @medusajs/medusa-cli@latest
+#   Copy app source code
+COPY ./backend /app/medusa
+#   Image entrypoint develop
+ENTRYPOINT ["/bin/sh", "./develop.sh", "develop"]

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,47 +1,24 @@
-FROM node:17.1.0 as builder
+#Dependencies
+FROM node:18-alpine3.16 as deps
+WORKDIR /app/medusa/
+#   Copy backend package package.json and yarn.lock from /backend
+COPY ./backend/package.json .
+COPY ./backend/yarn.lock .
+#   Install deps
+RUN yarn install --frozen-lockfile
 
-WORKDIR /app/medusa
-
-COPY . . 
-
-RUN rm -rf node_modules
-
-RUN apt-get update
-
-RUN apt-get install -y python
-
-RUN npm install -g npm@latest
-
-RUN npm install --loglevel=error
-
-RUN npm run build
-
-
-FROM node:17.1.0
-
-WORKDIR /app/medusa
-
-RUN mkdir dist
-
-COPY package*.json ./ 
-
-COPY develop.sh .
-
-COPY .env .
-
-COPY medusa-config.js .
-
-RUN apt-get update
-
-RUN apt-get install -y python
-# RUN apk add --no-cache python3
-
-RUN npm install -g @medusajs/medusa-cli
-
-RUN npm i --only=production
-
-COPY --from=builder /app/medusa/dist ./dist
-
-EXPOSE 9000
-
-ENTRYPOINT ["./develop.sh", "start"]
+#Build
+FROM node:18-alpine3.16 as builder
+WORKDIR /app/medusa/
+#   Copy cached node_modules from deps
+COPY --from=deps /app/medusa/node_modules /app/medusa/node_modules
+#   Install python and medusa-cli
+RUN apk update
+RUN apk add python3
+RUN yarn global add @medusajs/medusa-cli@latest
+#   Copy app source code
+COPY ./backend /app/medusa
+#   Build the app
+RUN yarn build
+#   Start the image with a shell script
+ENTRYPOINT ["/bin/sh", "./develop.sh", "start"]

--- a/storefront/Dockerfile
+++ b/storefront/Dockerfile
@@ -1,19 +1,19 @@
-FROM node:latest
+#Dependencies
+FROM node:18-alpine3.16 as deps
+WORKDIR /app/storefront/
+#   Copy storefront package package.json and yarn.lock from /storefront
+COPY ./package.json .
+COPY ./yarn.lock .
+#   Install deps
+RUN yarn install --frozen-lockfile
 
-WORKDIR /app/storefront
+#Build
+FROM node:18-alpine3.16 as runner
+WORKDIR /app/storefront/
+#   Copy cached node_modules from deps
+COPY --from=deps /app/storefront/node_modules /app/storefront/node_modules
+#   Copy app source code and monorepo root package.json
+COPY ./storefront /app/storefront
 
-COPY . .
-
-RUN rm -rf node_modules
-
-RUN apt-get update
-
-RUN npm install -g npm@latest
-
-RUN npm install -g gatsby-cli
-
-RUN npm install sharp
-
-RUN npm install --loglevel=error
-
-ENTRYPOINT ["gatsby", "develop", "-H", "0.0.0.0", "-p", "8000" ]
+#   Run the storefront in dev mode
+ENTRYPOINT [ "yarn", "dev" ]

--- a/storefront/Dockerfile.prod
+++ b/storefront/Dockerfile.prod
@@ -1,25 +1,20 @@
-FROM node:17.1.0 as builder
+#Dependencies
+FROM node:18-alpine3.16 as deps
+WORKDIR /app/storefront/
+#   Copy storefront package.json and yarn.lock from /storefront
+COPY ./storefront/package.json .
+COPY ./storefront/yarn.lock .
+#   Install deps and launch patch-package
+RUN yarn install --frozen-lockfile
 
-WORKDIR /app/storefront
-
-COPY . . 
-
-RUN rm -rf node_modules
-
-RUN apt-get update
-
-RUN yarn global add gatsby-cli
-
-RUN yarn add sharp
-
-RUN yarn install
-
-RUN gatsby build
-
-FROM nginx
-
-EXPOSE 80
-
-COPY --from=builder /app/storefront/public /usr/share/nginx/html
-
-ENTRYPOINT ["nginx", "-g", "daemon off;"]
+#Build
+FROM node:18-alpine3.16 as builder
+WORKDIR /app/storefront/
+#   Copy cached root and package node_modules from deps
+COPY --from=deps /app/storefront/node_modules /app/storefront/node_modules
+#   Copy app source code and monorepo root package.json
+COPY ./storefront /app/storefront/
+#   Build the app
+RUN yarn build
+#   Run the builded app
+ENTRYPOINT [ "yarn", "start" ]


### PR DESCRIPTION
Here are some updated dockerfiles for backend and storefront.
I did not update admin because I am using it through the node_module in the medusa backend (don't know if the separate admin app is depreciated. I followed the starter documentation).

I don't think the dockerfile are perfect but that is what I have managed to create when dockerizing my own project.
I make this PR so someone can have a more updated version to customize and tweak to what is needed.

The storefront is not gatsby anymore since it is deprecated and replaced by the nextjs starter.